### PR TITLE
Added methods to access duration, origin value and target value.

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -21,9 +21,12 @@ rampDouble	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-go	KEYWORD2
-update	KEYWORD2
+duration	KEYWORD2
 value	KEYWORD2
+origin	KEYWORD2
+target	KEYWORD2
+update	KEYWORD2
+go	KEYWORD2
 isFinished	KEYWORD2
 isRunning	KEYWORD2
 isPaused	KEYWORD2

--- a/src/Ramp.cpp
+++ b/src/Ramp.cpp
@@ -38,8 +38,23 @@ void _ramp<T>::init(T _val) {
  -----------------------------*/
 
 template <class T>
+unsigned long _ramp<T>::duration() {
+    return dur;
+}
+
+template <class T>
 T _ramp<T>::value() {
     return val;
+}
+
+template <class T>
+T _ramp<T>::origin() {
+    return A;
+}
+
+template <class T>
+T _ramp<T>::target() {
+    return B;
 }
 
 template <class T>

--- a/src/Ramp.h
+++ b/src/Ramp.h
@@ -92,7 +92,10 @@ private:
 public:
     _ramp();                                        // default constructor
     _ramp(T);                                       // constructor with initial value
-    T value();                              		// get value
+    unsigned long duration();                       // get duration of the interpolation
+    T value();                              		// get current interpolated value
+    T origin();                                     // get origin value of the interpolation
+    T target();                                     // get target value of the interpolation
     T update();                             		// update values
     T go(T);                                		// go directly to a new value
     T go(T, unsigned long);                         // ramp to _val, within _dur


### PR DESCRIPTION
After seeing what @XRobots had to do in his openDog project to circumvent the inaccessibility of the target value I thought I could maybe improve this library by adding a few getters that can easily be handy.

I made sure to make the getters coherent with the naming of `value()`.