### PR TITLE
Update Ramp.cpp

### DIFF
--- a/src/Ramp.cpp
+++ b/src/Ramp.cpp
@@ -97,7 +97,7 @@ T _ramp<T>::go(T _val, unsigned long _dur, ramp_mode _mode, loop_mode _loop) {
 template <class T>
 T _ramp<T>::update() {
     bool doUpdate = true;
-    unsigned long newTime;
+    unsigned long newTime = 0;
     unsigned long delta = grain;
     
     if (automated) {
@@ -176,6 +176,7 @@ bool _ramp<T>::isFinished() {
         return (pos>=dur);
     if (speed==BACKWARD)
         return (pos<=0);
+    return false;
 }
 
 template <class T>


### PR DESCRIPTION
Both changes prevent a warning when compiling for teensy (4.0). Setting the `newTime` variable prevents the warning 

> 'newTime' may be used uninitialized in this function [-Wmaybe-uninitialized].

The `isFinished()` function had the following warning: 

> control reaches end of non-void function [-Wreturn-type].

 Returning false as a standard prevented this.