### PR TITLE
Keeping pos <= dur

### DIFF
--- a/src/Ramp.cpp
+++ b/src/Ramp.cpp
@@ -134,6 +134,7 @@ T _ramp<T>::update() {
             }
         
             if (mode != NONE) {
+		if(pos > dur) pos = dur;
                 float k = (float)pos/(float)dur;
                 val = A + (B-A)*ramp_calc(k,mode);
                 constrain(val,A,B);                             //potential


### PR DESCRIPTION
there are some rare casese where pos > dur, which makes k > 1 and therefore breaks the code.

K is only checked to be == 1 or == 0 in ramp_calc, but never if it happens to get bigger or smaller. Correcting this would not make a change, because pos would stay above dur. 

Therefor pos itself need to be lowered before calculating k.